### PR TITLE
Fixed regex for matching incoming messages

### DIFF
--- a/app/js/services/rpc.js
+++ b/app/js/services/rpc.js
@@ -100,7 +100,7 @@ angular.module('EiskaltRPC', []).factory('EiskaltRPC', function($http, $q) {
             var promise = deferred.promise;
             jsonrpc('hub.getchat', {huburl: huburl, separator: '┴'}, true).success(function(messages) {
                 deferred.resolve(messages.map(function(msg) {
-                    var match = msg.match(/^\s*(\[[^\]]*\])\s*<\s*([^\s>]*)\s*>\s*([^\s]*)\s*$/);
+                    var match = msg.match(/^\s*(\[[^\]]*\])\s*<\s*([^\s>]*)\s*>\s*(.*)\s*$/);
                     return {
                         time: match[1],
                         nick: match[2],


### PR DESCRIPTION
The regex for matching incoming messages did not allow withspaces in message text. This is fixed now.